### PR TITLE
PCI internal, external, revision, and subsystem IDs

### DIFF
--- a/Header Files/NvidiaGpu.h
+++ b/Header Files/NvidiaGpu.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <PciIdentifier.h>
 #include <PhysicalGpuAdapter.h>
 
 namespace NVAPIAdapter
@@ -50,6 +51,9 @@ namespace NVAPIAdapter
 		{
 			System::String^ get();
 		}
+
+		/// <returns>The GPU PCI internal, external, revision, and subsystem IDs via the IPciIdentifier object.</returns>
+		IPciIdentifier^ GetPciIdentifier();
 	};
 
 	ref class NvidiaGpu : INvidiaGpu
@@ -62,6 +66,7 @@ namespace NVAPIAdapter
 		virtual property System::String^ Name { System::String^ get(); }
 		virtual property System::String^ SystemType { System::String^ get(); }
 		virtual property System::String^ BusType { System::String^ get(); }
+		virtual IPciIdentifier^ GetPciIdentifier();
 
 	private:
 		IPhysicalGpuAdapter^ m_physicalGpu;

--- a/Header Files/PciIdentifier.h
+++ b/Header Files/PciIdentifier.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2024 Anthony Alexander
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+namespace NVAPIAdapter
+{
+	public interface class IPciIdentifier
+	{
+		property System::UInt32 InternalId
+		{
+			System::UInt32 get();
+		}
+
+		property System::UInt32 ExternalId
+		{
+			System::UInt32 get();
+		}
+
+		property System::UInt32 RevisionId
+		{
+			System::UInt32 get();
+		}
+
+		property System::UInt32 SubsystemId
+		{
+			System::UInt32 get();
+		}
+	};
+
+	ref class PciIdentifier : IPciIdentifier
+	{
+	public:
+		PciIdentifier(const System::UInt32 internalId, const System::UInt32 externalId,
+			const System::UInt32 revisionId, const System::UInt32 subsystemId)
+		{
+			m_internalId = internalId;
+			m_externalId = externalId;
+			m_revisionId = revisionId;
+			m_subsystemId = subsystemId;
+		}
+
+		virtual property System::UInt32 InternalId
+		{
+			System::UInt32 get() { return m_internalId; };
+		}
+
+		virtual property System::UInt32 ExternalId
+		{
+			System::UInt32 get() { return m_externalId; };
+		}
+
+		virtual property System::UInt32 RevisionId
+		{
+			System::UInt32 get() { return m_revisionId; };
+		}
+
+		virtual property System::UInt32 SubsystemId
+		{
+			System::UInt32 get() { return m_subsystemId; };
+		}
+
+	private:
+		System::UInt32 m_internalId{ 0ul };
+		System::UInt32 m_externalId{ 0ul };
+		System::UInt32 m_revisionId{ 0ul };
+		System::UInt32 m_subsystemId{ 0ul };
+	};
+}

--- a/Header Files/PhysicalGpuAdapter.h
+++ b/Header Files/PhysicalGpuAdapter.h
@@ -31,6 +31,10 @@ namespace NVAPIAdapter
 		System::String^ GetFullName();
 		System::String^ GetBusType();
 		System::String^ GetSystemType();
+		unsigned long GetPciInternalId();
+		unsigned long GetPciExternalId();
+		unsigned long GetPciRevisionId();
+		unsigned long GetPciSubsystemId();
 	};
 
 	ref class PhysicalGpuAdapter : IPhysicalGpuAdapter
@@ -42,6 +46,10 @@ namespace NVAPIAdapter
 		virtual System::String^ GetFullName() { return gcnew System::String(m_physicalGpu->GetFullName().c_str()); }
 		virtual System::String^ GetBusType() { return gcnew System::String(m_physicalGpu->GetBusType().c_str()); }
 		virtual System::String^ GetSystemType() { return gcnew System::String(m_physicalGpu->GetSystemType().c_str()); }
+		virtual unsigned long GetPciInternalId() { return m_physicalGpu->GetPciInternalId(); }
+		virtual unsigned long GetPciExternalId() { return m_physicalGpu->GetPciExternalId(); }
+		virtual unsigned long GetPciRevisionId() { return m_physicalGpu->GetPciRevisionId(); }
+		virtual unsigned long GetPciSubsystemId() { return m_physicalGpu->GetPciSubsystemId(); }
 
 	private:
 		NVAPIHooks::IPhysicalGpu* m_physicalGpu = nullptr;

--- a/IntegrationTest/TestPanel.Designer.cs
+++ b/IntegrationTest/TestPanel.Designer.cs
@@ -55,6 +55,7 @@ namespace NVAPIAdapter.IntegrationTest
             CoreCountButton = new Button();
             BusTypeButton = new Button();
             SystemTypeButton = new Button();
+            PciIdButton = new Button();
             SuspendLayout();
             // 
             // InstructionLabel
@@ -110,11 +111,23 @@ namespace NVAPIAdapter.IntegrationTest
             SystemTypeButton.UseVisualStyleBackColor = true;
             SystemTypeButton.Click += SystemTypeButton_Click;
             // 
+            // PciIdButton
+            // 
+            PciIdButton.Enabled = false;
+            PciIdButton.Location = new Point(501, 92);
+            PciIdButton.Name = "PciIdButton";
+            PciIdButton.Size = new Size(157, 71);
+            PciIdButton.TabIndex = 5;
+            PciIdButton.Text = "PCI Identifiers";
+            PciIdButton.UseVisualStyleBackColor = true;
+            PciIdButton.Click += PciIdButton_Click;
+            // 
             // TestPanel
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
+            Controls.Add(PciIdButton);
             Controls.Add(SystemTypeButton);
             Controls.Add(BusTypeButton);
             Controls.Add(CoreCountButton);
@@ -133,5 +146,6 @@ namespace NVAPIAdapter.IntegrationTest
         private Button CoreCountButton;
         private Button BusTypeButton;
         private Button SystemTypeButton;
+        private Button PciIdButton;
     }
 }

--- a/IntegrationTest/TestPanel.cs
+++ b/IntegrationTest/TestPanel.cs
@@ -57,6 +57,7 @@ namespace NVAPIAdapter.IntegrationTest
             CoreCountButton.Enabled = true;
             BusTypeButton.Enabled = true;
             SystemTypeButton.Enabled = true;
+            PciIdButton.Enabled = true;
         }
 
         [NotNull] INvidiaGpu SelectedGpu => mySelectedGpu ?? throw new NullReferenceException("GPU was not selected.");
@@ -74,6 +75,16 @@ namespace NVAPIAdapter.IntegrationTest
         private void SystemTypeButton_Click(object sender, EventArgs e)
         {
             MessageBox.Show(SelectedGpu.SystemType, caption: "GPU System Type", MessageBoxButtons.OK);
+        }
+
+        private void PciIdButton_Click(object sender, EventArgs e)
+        {
+            var pciIdentifier = SelectedGpu.GetPciIdentifier();
+            var message = $@"Internal ID: {pciIdentifier.InternalId}
+External ID: {pciIdentifier.ExternalId}
+Revision ID: {pciIdentifier.RevisionId}
+Subsystem ID: {pciIdentifier.SubsystemId}";
+            MessageBox.Show(message, caption: "PCI Identifiers", MessageBoxButtons.OK);
         }
     }
 }

--- a/NVAPIAdapter.vcxproj
+++ b/NVAPIAdapter.vcxproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ClInclude Include="Header Files\NVAPI.h" />
     <ClInclude Include="Header Files\NvidiaGpu.h" />
+    <ClInclude Include="Header Files\PciIdentifier.h" />
     <ClInclude Include="Header Files\PhysicalGpuAdapter.h" />
   </ItemGroup>
   <ItemGroup>

--- a/NVAPIAdapter.vcxproj.filters
+++ b/NVAPIAdapter.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClInclude Include="Header Files\PhysicalGpuAdapter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Header Files\PciIdentifier.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source Files\NVAPI.cpp">

--- a/NVAPIHooks/Header Files/ApiTunnel.h
+++ b/NVAPIHooks/Header Files/ApiTunnel.h
@@ -84,5 +84,15 @@ namespace NVAPIHooks
 		/// <param name="systemType">Caches the GPU system type.</param>
 		/// <returns>NVAPI status code for determining the GPU system type.</returns>
 		HOOKS_API NvAPI_Status GetSystemType(NvPhysicalGpuHandle gpuHandle, NV_SYSTEM_TYPE* systemType);
+
+		/// <summary>Determines the GPU PCI identifiers.</summary>
+		/// <param name="gpuHandle">Single physical GPU handle.</param>
+		/// <param name="internalDeviceId">Caches the internal PCI device identifier.</param>
+		/// <param name="subsystemId">Caches the subsystem PCI device identifier.</param>
+		/// <param name="revisionId">Caches the device-specific revision identifier.</param>
+		/// <param name="externalDeviceId">Caches the external PCI device identifier.</param>
+		/// <returns>NVAPI status code for determining the GPU PCI identifiers.</returns>
+		HOOKS_API NvAPI_Status GetPciIdentifiers(NvPhysicalGpuHandle gpuHandle, unsigned long* internalDeviceId,
+			unsigned long* subsystemId, unsigned long* revisionId, unsigned long* externalDeviceId);
 	}
 }

--- a/NVAPIHooks/Header Files/PciIdentifierTypes.h
+++ b/NVAPIHooks/Header Files/PciIdentifierTypes.h
@@ -20,42 +20,14 @@
 
 #pragma once
 
-#include <string>
-
 namespace NVAPIHooks
 {
-	class IPhysicalGpu
+	enum class PciIdentifierType
 	{
-	public:
-		IPhysicalGpu() = default;
-		~IPhysicalGpu() = default;
-		IPhysicalGpu(const IPhysicalGpu&) = delete;
-		IPhysicalGpu(IPhysicalGpu&&) = delete;
-		IPhysicalGpu& operator = (const IPhysicalGpu&) = delete;
-		IPhysicalGpu& operator = (IPhysicalGpu&&) = delete;
-
-		/// <returns>Number of cores defined for the GPU.</returns>
-		virtual unsigned long GetCoreCount() = 0;
-
-		/// <returns>The name of the GPU.</returns>
-		virtual std::string GetFullName() = 0;
-
-		/// <returns>The GPU bus type such as PCIe.</returns>
-		virtual std::string GetBusType() = 0;
-
-		/// <returns>The GPU system type such as Laptop or Desktop.</returns>
-		virtual std::string GetSystemType() = 0;
-
-		/// <returns>The PCI internal identifier value.</returns>
-		virtual unsigned long GetPciInternalId() = 0;
-
-		/// <returns>The PCI external identifier value.</returns>
-		virtual unsigned long GetPciExternalId() = 0;
-
-		/// <returns>The PCI revision identifier value.</returns>
-		virtual unsigned long GetPciRevisionId() = 0;
-
-		/// <returns>The PCI subsystem indentifer value.</returns>
-		virtual unsigned long GetPciSubsystemId() = 0;
+		INTERNAL,
+		EXTERNAL,
+		REVISION,
+		SUBSYSTEM,
+		UNKNOWN,
 	};
 }

--- a/NVAPIHooks/Header Files/PhysicalGpu.h
+++ b/NVAPIHooks/Header Files/PhysicalGpu.h
@@ -23,6 +23,7 @@
 #include <Export.h>
 #include <IPhysicalGpu.h>
 #include <nvapi.h>
+#include <PciIdentifierTypes.h>
 #include <unordered_map>
 
 namespace NVAPIHooks
@@ -47,6 +48,10 @@ namespace NVAPIHooks
 		HOOKS_API std::string GetFullName() override;
 		HOOKS_API std::string GetBusType() override;
 		HOOKS_API std::string GetSystemType() override;
+		HOOKS_API unsigned long GetPciInternalId() override;
+		HOOKS_API unsigned long GetPciExternalId() override;
+		HOOKS_API unsigned long GetPciRevisionId() override;
+		HOOKS_API unsigned long GetPciSubsystemId() override;
 
 	private:
 		NvPhysicalGpuHandle m_physicalGpuHandle{ NVAPI_DEFAULT_HANDLE };
@@ -59,5 +64,7 @@ namespace NVAPIHooks
 			{NV_GPU_BUS_TYPE::NVAPI_GPU_BUS_TYPE_FPCI, "FPCI"},
 			{NV_GPU_BUS_TYPE::NVAPI_GPU_BUS_TYPE_AXI, "AXI"},
 		};
+
+		[[nodiscard]] HOOKS_API unsigned long GetPciIdentifier(const PciIdentifierType idType);
 	};
 }

--- a/NVAPIHooks/Header Files/pch.h
+++ b/NVAPIHooks/Header Files/pch.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <nvapi.h>
 #include <string>
+#include <stdexcept>
 #include <vector>
 #include <unordered_map>
 

--- a/NVAPIHooks/IntegrationTest/main.cpp
+++ b/NVAPIHooks/IntegrationTest/main.cpp
@@ -38,6 +38,10 @@ int main()
     std::cout << "Core count: " << physicalGpu->GetCoreCount() << std::endl;
     std::cout << "Bus type: " << physicalGpu->GetBusType() << std::endl;
     std::cout << "System type: " << physicalGpu->GetSystemType() << std::endl;
+    std::cout << "PCI internal ID: " << physicalGpu->GetPciInternalId() << std::endl;
+    std::cout << "PCI external ID: " << physicalGpu->GetPciExternalId() << std::endl;
+    std::cout << "PCI revision ID: " << physicalGpu->GetPciRevisionId() << std::endl;
+    std::cout << "PCI subsystem ID: " << physicalGpu->GetPciSubsystemId() << std::endl;
     std::cout << "\n";
     std::cout << "Unloading API...\n";
     GeneralApi::Unload();

--- a/NVAPIHooks/NVAPIHooks.vcxproj
+++ b/NVAPIHooks/NVAPIHooks.vcxproj
@@ -17,6 +17,7 @@
     <ClInclude Include="Header Files\GeneralApi.h" />
     <ClInclude Include="Header Files\IPhysicalGpu.h" />
     <ClInclude Include="Header Files\pch.h" />
+    <ClInclude Include="Header Files\PciIdentifierTypes.h" />
     <ClInclude Include="Header Files\PhysicalGpu.h" />
   </ItemGroup>
   <ItemGroup>

--- a/NVAPIHooks/NVAPIHooks.vcxproj.filters
+++ b/NVAPIHooks/NVAPIHooks.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClInclude Include="Header Files\IPhysicalGpu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Header Files\PciIdentifierTypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source Files\pch.cpp">

--- a/NVAPIHooks/Source Files/ApiTunnel.cpp
+++ b/NVAPIHooks/Source Files/ApiTunnel.cpp
@@ -64,5 +64,11 @@ namespace NVAPIHooks
 		{
 			return NvAPI_GPU_GetSystemType(gpuHandle, systemType);
 		}
+
+		NvAPI_Status GetPciIdentifiers(NvPhysicalGpuHandle gpuHandle, unsigned long* internalDeviceId,
+			unsigned long* subSystemId, unsigned long* revisionId, unsigned long* externalDeviceId)
+		{
+			return NvAPI_GPU_GetPCIIdentifiers(gpuHandle, internalDeviceId, subSystemId, revisionId, externalDeviceId);
+		}
 	}
 }

--- a/NVAPIHooks/Source Files/PhysicalGpu.cpp
+++ b/NVAPIHooks/Source Files/PhysicalGpu.cpp
@@ -67,6 +67,41 @@ namespace NVAPIHooks
 		case NV_SYSTEM_TYPE::NV_SYSTEM_TYPE_DESKTOP: return "Desktop";
 		default: return "Unknown";
 		}
+	}
 
+	unsigned long PhysicalGpu::GetPciIdentifier(const PciIdentifierType idType)
+	{
+		unsigned long internalId, subsystemId, revisionId, externalId;
+		const auto status = ApiTunnel::GetPciIdentifiers(m_physicalGpuHandle, &internalId, &subsystemId, &revisionId, &externalId);
+		if (status != NvAPI_Status::NVAPI_OK) throw ApiError("Failed to determine PCI identifiers.", status);
+
+		switch (idType)
+		{
+		case PciIdentifierType::INTERNAL: return internalId;
+		case PciIdentifierType::EXTERNAL: return externalId;
+		case PciIdentifierType::REVISION: return revisionId;
+		case PciIdentifierType::SUBSYSTEM: return subsystemId;
+		default: throw std::invalid_argument("Unknown PCI identifier type provided.");
+		}
+	}
+
+	unsigned long PhysicalGpu::GetPciInternalId()
+	{
+		return GetPciIdentifier(PciIdentifierType::INTERNAL);
+	}
+
+	unsigned long PhysicalGpu::GetPciExternalId()
+	{
+		return GetPciIdentifier(PciIdentifierType::EXTERNAL);
+	}
+
+	unsigned long PhysicalGpu::GetPciRevisionId()
+	{
+		return GetPciIdentifier(PciIdentifierType::REVISION);
+	}
+
+	unsigned long PhysicalGpu::GetPciSubsystemId()
+	{
+		return GetPciIdentifier(PciIdentifierType::SUBSYSTEM);
 	}
 }

--- a/NVAPIHooks/UnitTest/Source Files/PhysicalGpuTester.cpp
+++ b/NVAPIHooks/UnitTest/Source Files/PhysicalGpuTester.cpp
@@ -224,6 +224,161 @@ namespace NVAPIHooks
 				Assert::ExpectException<ApiError>(act);
 			}
 
+			TEST_METHOD(GetPciInternalId_OnSuccess_ReturnsInternalId)
+			{
+				// Arrange
+				const unsigned long expected = 11102024ul;
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).With(m_fakeGpuHandle, _, _, _, _)
+					.Do([&](NvPhysicalGpuHandle, unsigned long* internalId, unsigned long*,
+						unsigned long*, unsigned long*) -> NvAPI_Status
+						{
+							*internalId = expected;
+							return NvAPI_Status::NVAPI_OK;
+						});
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto actual = physicalGpu->GetPciInternalId();
+
+				// Assert
+				Assert::AreEqual(expected, actual);
+			}
+
+			TEST_METHOD(GetPciInternalId_OnFailure_Throws)
+			{
+				// Arrange
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).Return(NvAPI_Status::NVAPI_ERROR);
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto act = [&]() -> unsigned long { return physicalGpu->GetPciInternalId(); };
+
+				// Assert
+				Assert::ExpectException<ApiError>(act);
+			}
+
+			TEST_METHOD(GetPciExternalId_OnSuccess_ReturnsExternalId)
+			{
+				// Arrange
+				const unsigned long expected = 1959ul;
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).With(m_fakeGpuHandle, _, _, _, _)
+					.Do([&](NvPhysicalGpuHandle, unsigned long*, unsigned long*,
+						unsigned long*, unsigned long* externalId) -> NvAPI_Status
+						{
+							*externalId = expected;
+							return NvAPI_Status::NVAPI_OK;
+						});
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto actual = physicalGpu->GetPciExternalId();
+
+				// Assert
+				Assert::AreEqual(expected, actual);
+			}
+
+			TEST_METHOD(GetPciExternalId_OnFailure_Throws)
+			{
+				// Arrange
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).Return(NvAPI_Status::NVAPI_ERROR);
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto act = [&]() -> unsigned long { return physicalGpu->GetPciExternalId(); };
+
+				// Assert
+				Assert::ExpectException<ApiError>(act);
+			}
+
+			TEST_METHOD(GetPciRevisionId_OnSuccess_ReturnsRevisionId)
+			{
+				// Arrange
+				const unsigned long expected = 3022024ul;
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).With(m_fakeGpuHandle, _, _, _, _)
+					.Do([&](NvPhysicalGpuHandle, unsigned long*, unsigned long*,
+						unsigned long* revisionId, unsigned long*) -> NvAPI_Status
+						{
+							*revisionId = expected;
+							return NvAPI_Status::NVAPI_OK;
+						});
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto actual = physicalGpu->GetPciRevisionId();
+
+				// Assert
+				Assert::AreEqual(expected, actual);
+			}
+
+			TEST_METHOD(GetPciRevisionId_OnFailure_Throws)
+			{
+				// Arrange
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).Return(NvAPI_Status::NVAPI_ERROR);
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto act = [&]() -> unsigned long { return physicalGpu->GetPciRevisionId(); };
+
+				// Assert
+				Assert::ExpectException<ApiError>(act);
+			}
+
+			TEST_METHOD(GetPciSubsystemId_OnSuccess_ReturnsSubsystemId)
+			{
+				// Arrange
+				const unsigned long expected = 8012019ul;
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).With(m_fakeGpuHandle, _, _, _, _)
+					.Do([&](NvPhysicalGpuHandle, unsigned long*, unsigned long* subsystemId,
+						unsigned long*, unsigned long*) -> NvAPI_Status
+						{
+							*subsystemId = expected;
+							return NvAPI_Status::NVAPI_OK;
+						});
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto actual = physicalGpu->GetPciSubsystemId();
+
+				// Assert
+				Assert::AreEqual(expected, actual);
+			}
+
+			TEST_METHOD(GetPciSubsystemId_OnFailure_Throws)
+			{
+				// Arrange
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).Return(NvAPI_Status::NVAPI_ERROR);
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto act = [&]() -> unsigned long { return physicalGpu->GetPciSubsystemId(); };
+
+				// Assert
+				Assert::ExpectException<ApiError>(act);
+			}
+
+			// Ideally, we don't test private methods as they get tested through the public ones that use them.
+			// This is an exception to that since we can't really pass an unknown type through the public methods.
+			TEST_METHOD(GetPciIdentifier_GivenUnknownPciIdType_Throws)
+			{
+				// Arrange
+				m_mocks.OnCallFunc(ApiTunnel::GetPciIdentifiers).Return(NvAPI_Status::NVAPI_OK);
+				const char* expectedMessage = "Unknown PCI identifier type provided.";
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				try
+				{
+					// Act
+					auto identifier = physicalGpu->GetPciIdentifier(PciIdentifierType::UNKNOWN);
+				}
+				catch (const std::invalid_argument& ex)
+				{
+					// Assert
+					Assert::AreEqual(expectedMessage, ex.what());
+					return;
+				}
+				Assert::Fail(L"Expected exception to be thrown but did not.");
+			}
+
 		private:
 			NvPhysicalGpuHandle m_fakeGpuHandle{ (NvPhysicalGpuHandle)1 };
 			MockRepository m_mocks;

--- a/Source Files/NvidiaGpu.cpp
+++ b/Source Files/NvidiaGpu.cpp
@@ -48,4 +48,13 @@ namespace NVAPIAdapter
 	{
 		return m_physicalGpu->GetSystemType();
 	}
+
+	IPciIdentifier^ NvidiaGpu::GetPciIdentifier()
+	{
+		const auto internalId = m_physicalGpu->GetPciInternalId();
+		const auto externalId = m_physicalGpu->GetPciExternalId();
+		const auto revisionId = m_physicalGpu->GetPciRevisionId();
+		const auto subsystemId = m_physicalGpu->GetPciSubsystemId();
+		return gcnew PciIdentifier(internalId, externalId, revisionId, subsystemId);
+	}
 }

--- a/UnitTest/NvidiaGpuTester.cs
+++ b/UnitTest/NvidiaGpuTester.cs
@@ -90,5 +90,33 @@ namespace NVAPIAdapter.UnitTest
             // Assert
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+        public void GetPciIdentifier_GivenIdentifier_ReturnsEachId()
+        {
+            // Arrange
+            const uint expectedInternalId = 11102024;
+            myFakePhysicalGpu.GetPciInternalId().Returns(expectedInternalId);
+
+            const uint expectedExternalId = 6212016;
+            myFakePhysicalGpu.GetPciExternalId().Returns(expectedExternalId);
+
+            const uint expectedRevisionId = 12202016;
+            myFakePhysicalGpu.GetPciRevisionId().Returns(expectedRevisionId);
+
+            const uint expectedSubsystemId = 2282020;
+            myFakePhysicalGpu.GetPciSubsystemId().Returns(expectedSubsystemId);
+
+            var gpu = CreateNvidiaGpu();
+
+            // Act
+            var pciIdentifier = gpu.GetPciIdentifier();
+
+            // Assert
+            Assert.AreEqual(expectedInternalId, pciIdentifier.InternalId);
+            Assert.AreEqual(expectedExternalId, pciIdentifier.ExternalId);
+            Assert.AreEqual(expectedRevisionId, pciIdentifier.RevisionId);
+            Assert.AreEqual(expectedSubsystemId, pciIdentifier.SubsystemId);
+        }
     }
 }


### PR DESCRIPTION
Updates the API to provide read-only values of the PCI internal, external, revision, and subsystem IDs. Since these IDs don't change, the IDs are provided by an `IPciIdentifier` interface so that users can obtain each ID once.