### PR TITLE
Video BIOS version

### DIFF
--- a/Header Files/NvidiaGpu.h
+++ b/Header Files/NvidiaGpu.h
@@ -66,6 +66,15 @@ namespace NVAPIAdapter
 		{
 			System::UInt32 get();
 		}
+
+		/// <summary>
+		/// The video BIOS version string in the format xx.xx.xx.xx.yy where the xx numbers
+		/// are the video BIOS version and the yy numbers are the manufacturer's version.
+		/// </summary>
+		property System::String^ VideoBiosVersion
+		{
+			System::String^ get();
+		}
 	};
 
 	ref class NvidiaGpu : INvidiaGpu
@@ -81,6 +90,7 @@ namespace NVAPIAdapter
 		virtual IPciIdentifier^ GetPciIdentifier();
 		virtual property System::UInt32 PhysicalFrameBufferSizeInKb { System::UInt32 get(); }
 		virtual property System::UInt32 VirtualFrameBufferSizeInKb { System::UInt32 get(); }
+		virtual property System::String^ VideoBiosVersion { System::String^ get(); }
 
 	private:
 		IPhysicalGpuAdapter^ m_physicalGpu;

--- a/Header Files/PhysicalGpuAdapter.h
+++ b/Header Files/PhysicalGpuAdapter.h
@@ -37,6 +37,7 @@ namespace NVAPIAdapter
 		unsigned long GetPciSubsystemId();
 		unsigned long GetPhysicalFrameBufferSizeInKb();
 		unsigned long GetVirtualFrameBufferSizeInKb();
+		System::String^ GetVideoBiosVersion();
 	};
 
 	ref class PhysicalGpuAdapter : IPhysicalGpuAdapter
@@ -54,6 +55,7 @@ namespace NVAPIAdapter
 		virtual unsigned long GetPciSubsystemId() { return m_physicalGpu->GetPciSubsystemId(); }
 		virtual unsigned long GetPhysicalFrameBufferSizeInKb() { return m_physicalGpu->GetPhysicalFrameBufferSize(); }
 		virtual unsigned long GetVirtualFrameBufferSizeInKb() { return m_physicalGpu->GetVirtualFrameBufferSize(); }
+		virtual System::String^ GetVideoBiosVersion() { return gcnew System::String(m_physicalGpu->GetVbiosVersion().c_str()); }
 
 	private:
 		NVAPIHooks::IPhysicalGpu* m_physicalGpu = nullptr;

--- a/IntegrationTest/TestPanel.Designer.cs
+++ b/IntegrationTest/TestPanel.Designer.cs
@@ -58,6 +58,7 @@ namespace NVAPIAdapter.IntegrationTest
             PciIdButton = new Button();
             PhysicalFrameBufferSizeButton = new Button();
             VirtualFrameBufferSizeButton = new Button();
+            VbiosButton = new Button();
             SuspendLayout();
             // 
             // InstructionLabel
@@ -146,11 +147,23 @@ namespace NVAPIAdapter.IntegrationTest
             VirtualFrameBufferSizeButton.UseVisualStyleBackColor = true;
             VirtualFrameBufferSizeButton.Click += VirtualFrameBufferSizeButton_Click;
             // 
+            // VbiosButton
+            // 
+            VbiosButton.Enabled = false;
+            VbiosButton.Location = new Point(175, 169);
+            VbiosButton.Name = "VbiosButton";
+            VbiosButton.Size = new Size(157, 71);
+            VbiosButton.TabIndex = 8;
+            VbiosButton.Text = "VBIOS Version";
+            VbiosButton.UseVisualStyleBackColor = true;
+            VbiosButton.Click += VbiosButton_Click;
+            // 
             // TestPanel
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(839, 450);
+            Controls.Add(VbiosButton);
             Controls.Add(VirtualFrameBufferSizeButton);
             Controls.Add(PhysicalFrameBufferSizeButton);
             Controls.Add(PciIdButton);
@@ -175,5 +188,6 @@ namespace NVAPIAdapter.IntegrationTest
         private Button PciIdButton;
         private Button PhysicalFrameBufferSizeButton;
         private Button VirtualFrameBufferSizeButton;
+        private Button VbiosButton;
     }
 }

--- a/IntegrationTest/TestPanel.cs
+++ b/IntegrationTest/TestPanel.cs
@@ -60,6 +60,7 @@ namespace NVAPIAdapter.IntegrationTest
             PciIdButton.Enabled = true;
             PhysicalFrameBufferSizeButton.Enabled = true;
             VirtualFrameBufferSizeButton.Enabled = true;
+            VbiosButton.Enabled = true;
         }
 
         [NotNull] INvidiaGpu SelectedGpu => mySelectedGpu ?? throw new NullReferenceException("GPU was not selected.");
@@ -99,6 +100,11 @@ Subsystem ID: {pciIdentifier.SubsystemId}";
         {
             MessageBox.Show(SelectedGpu.VirtualFrameBufferSizeInKb.ToString(),
                 caption: "GPU Virtual Frame Buffer Size", MessageBoxButtons.OK);
+        }
+
+        private void VbiosButton_Click(object sender, EventArgs e)
+        {
+            MessageBox.Show(SelectedGpu.VideoBiosVersion, caption: "VBIOS Version", MessageBoxButtons.OK);
         }
     }
 }

--- a/NVAPIHooks/Header Files/ApiTunnel.h
+++ b/NVAPIHooks/Header Files/ApiTunnel.h
@@ -110,5 +110,14 @@ namespace NVAPIHooks
 		/// <param name="bufferSize">Caches the virtual frame buffer size.</param>
 		/// <returns>NVAPI status code for determining the GPU virtual frame buffer size.</returns>
 		HOOKS_API NvAPI_Status GetVirtualFrameBufferSize(NvPhysicalGpuHandle gpuHandle, unsigned long* bufferSize);
+
+		/// <summary>
+		/// Determines the VBIOS version of the GPU in the form of xx.xx.xx.xx.yy where the
+		/// xx numbers represent the video BIOS version and the yy numbers are the manufacturer's revision.
+		/// </summary>
+		/// <param name="gpuHandle">Single physical GPU handle.</param>
+		/// <param name="vbiosVersion">Caches the VBIOS version.</param>
+		/// <returns>NVAPI status code for determining the GPU video BIOS version string.</returns>
+		HOOKS_API NvAPI_Status GetVbiosVersion(NvPhysicalGpuHandle gpuHandle, char* vbiosVersion);
 	}
 }

--- a/NVAPIHooks/Header Files/IPhysicalGpu.h
+++ b/NVAPIHooks/Header Files/IPhysicalGpu.h
@@ -63,5 +63,11 @@ namespace NVAPIHooks
 
 		/// <returns>The virtual frame buffer size in KB. Includes both physical and any dedicated RAM.</returns>
 		virtual unsigned long GetVirtualFrameBufferSize() = 0;
+
+		/// <returns>
+		/// The video BIOS string in the form of xx.xx.xx.xx.yy where the xx numbers are 
+		/// the video BIOS version and the yy numbers are the manufacturer's version.
+		/// </returns>
+		virtual std::string GetVbiosVersion() = 0;
 	};
 }

--- a/NVAPIHooks/Header Files/PhysicalGpu.h
+++ b/NVAPIHooks/Header Files/PhysicalGpu.h
@@ -54,6 +54,7 @@ namespace NVAPIHooks
 		HOOKS_API unsigned long GetPciSubsystemId() override;
 		HOOKS_API unsigned long GetPhysicalFrameBufferSize() override;
 		HOOKS_API unsigned long GetVirtualFrameBufferSize() override;
+		HOOKS_API std::string GetVbiosVersion() override;
 
 	private:
 		NvPhysicalGpuHandle m_physicalGpuHandle{ NVAPI_DEFAULT_HANDLE };

--- a/NVAPIHooks/IntegrationTest/main.cpp
+++ b/NVAPIHooks/IntegrationTest/main.cpp
@@ -44,6 +44,7 @@ int main()
     std::cout << "PCI subsystem ID: " << physicalGpu->GetPciSubsystemId() << std::endl;
     std::cout << "Physical frame buffer size (KB): " << physicalGpu->GetPhysicalFrameBufferSize() << std::endl;
     std::cout << "Virtual frame buffer size (KB): " << physicalGpu->GetVirtualFrameBufferSize() << std::endl;
+    std::cout << "Video BIOS version: " << physicalGpu->GetVbiosVersion() << std::endl;
     std::cout << "\n";
     std::cout << "Unloading API...\n";
     GeneralApi::Unload();

--- a/NVAPIHooks/Source Files/ApiTunnel.cpp
+++ b/NVAPIHooks/Source Files/ApiTunnel.cpp
@@ -80,5 +80,10 @@ namespace NVAPIHooks
 		{
 			return NvAPI_GPU_GetVirtualFrameBufferSize(gpuHandle, bufferSize);
 		}
+
+		NvAPI_Status GetVbiosVersion(NvPhysicalGpuHandle gpuHandle, char* vbiosVersion)
+		{
+			return NvAPI_GPU_GetVbiosVersionString(gpuHandle, vbiosVersion);
+		}
 	}
 }

--- a/NVAPIHooks/Source Files/PhysicalGpu.cpp
+++ b/NVAPIHooks/Source Files/PhysicalGpu.cpp
@@ -120,4 +120,12 @@ namespace NVAPIHooks
 		if (status == NvAPI_Status::NVAPI_OK) return bufferSize;
 		throw ApiError("Failed to determine GPU virtual frame buffer size.", status);
 	}
+
+	std::string PhysicalGpu::GetVbiosVersion()
+	{
+		char vbiosVersion[NVAPI_SHORT_STRING_MAX];
+		const auto status = ApiTunnel::GetVbiosVersion(m_physicalGpuHandle, vbiosVersion);
+		if (status == NvAPI_Status::NVAPI_OK) return std::string(vbiosVersion);
+		throw ApiError("Failed to determine GPU video BIOS string.", status);
+	}
 }

--- a/NVAPIHooks/UnitTest/Source Files/PhysicalGpuTester.cpp
+++ b/NVAPIHooks/UnitTest/Source Files/PhysicalGpuTester.cpp
@@ -443,7 +443,7 @@ namespace NVAPIHooks
 				Assert::ExpectException<ApiError>(act);
 			}
 
-			TEST_METHOD(GetVbioVersion_OnSuccess_ReturnsVbiosVersion)
+			TEST_METHOD(GetVbiosVersion_OnSuccess_ReturnsVbiosVersion)
 			{
 				// Arrange
 				const std::string expected = "01.23.45.67.89";

--- a/NVAPIHooks/UnitTest/Source Files/PhysicalGpuTester.cpp
+++ b/NVAPIHooks/UnitTest/Source Files/PhysicalGpuTester.cpp
@@ -443,6 +443,38 @@ namespace NVAPIHooks
 				Assert::ExpectException<ApiError>(act);
 			}
 
+			TEST_METHOD(GetVbioVersion_OnSuccess_ReturnsVbiosVersion)
+			{
+				// Arrange
+				const std::string expected = "01.23.45.67.89";
+				m_mocks.OnCallFunc(ApiTunnel::GetVbiosVersion).With(m_fakeGpuHandle, _)
+					.Do([&](NvPhysicalGpuHandle, char* vbiosVersion) -> NvAPI_Status
+						{
+							sprintf_s(vbiosVersion, sizeof(expected), expected.c_str());
+							return NvAPI_Status::NVAPI_OK;
+						});
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto actual = physicalGpu->GetVbiosVersion();
+
+				// Assert
+				Assert::AreEqual(expected, actual);
+			}
+
+			TEST_METHOD(GetVbiosVersion_OnFailure_Throws)
+			{
+				// Arrange
+				m_mocks.OnCallFunc(ApiTunnel::GetVbiosVersion).Return(NvAPI_Status::NVAPI_ERROR);
+				auto physicalGpu = std::make_unique<PhysicalGpu>(m_fakeGpuHandle);
+
+				// Act
+				auto act = [&]() -> std::string {return physicalGpu->GetVbiosVersion(); };
+
+				// Assert
+				Assert::ExpectException<ApiError>(act);
+			}
+
 		private:
 			NvPhysicalGpuHandle m_fakeGpuHandle{ (NvPhysicalGpuHandle)1 };
 			MockRepository m_mocks;

--- a/Source Files/NvidiaGpu.cpp
+++ b/Source Files/NvidiaGpu.cpp
@@ -67,4 +67,9 @@ namespace NVAPIAdapter
 	{
 		return m_physicalGpu->GetVirtualFrameBufferSizeInKb();
 	}
+
+	String^ NvidiaGpu::VideoBiosVersion::get()
+	{
+		return m_physicalGpu->GetVideoBiosVersion();
+	}
 }

--- a/UnitTest/NvidiaGpuTester.cs
+++ b/UnitTest/NvidiaGpuTester.cs
@@ -148,5 +148,20 @@ namespace NVAPIAdapter.UnitTest
             // Assert
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+        public void VideoBiosVersion_GivenVersionString_ReturnsIt()
+        {
+            // Arrange
+            const string expected = "AA.BB.CC.DD.EE";
+            myFakePhysicalGpu.GetVideoBiosVersion().Returns(expected);
+            var gpu = CreateNvidiaGpu();
+
+            // Act
+            var actual = gpu.VideoBiosVersion;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Adds the API to return the video BIOS version of the GPU in the format of XX.XX.XX.XX.YY where:
- The XX numbers represent the video BIOS version.
- The YY numbers represent the original equipment manufacturer's (OEM) version number.